### PR TITLE
Minor fix for multi-GPU inference

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ roman==4.1
 scipy==1.11.2
 transformers==4.33.2
 vllm==0.1.7
+pyarrow==14.0.1
+pandas==2.1.3
+ray==2.8.0

--- a/scripts/plan/config.yaml
+++ b/scripts/plan/config.yaml
@@ -1,5 +1,5 @@
 # MODEL ARGS:
-# for model server / sampling args, you can put them under MODEL to be shared, 
+# for model server / sampling args, you can put them under MODEL to be shared,
 # or under the specific pipeline steps (SETTING/ENTITY/etc) for specific options. unspecified sampling args will inherit from the ancestor.
 # the format is the same as the openai API, since VLLM also provides and openai-style API.
 
@@ -9,6 +9,7 @@ defaults:
   logging_level: info # debug, info, warning, error, critical
   MODEL:
     engine: TODO # TODO path/to/vllm-supported/hf/model, vllm-supported huggingface model string, or openai model string
+    tensor_parallel_size: 1 # TODO number of gpus to use
     server_type: vllm # "vllm" or "openai"
     host: http://localhost # model server if using vllm
     port: 9741

--- a/scripts/premise/config.yaml
+++ b/scripts/premise/config.yaml
@@ -1,5 +1,5 @@
 # MODEL ARGS:
-# for model server / sampling args, you can put them under MODEL to be shared, 
+# for model server / sampling args, you can put them under MODEL to be shared,
 # or under the specific pipeline steps (TITLE / PREMISE) for specific options. unspecified sampling args will inherit from the ancestor.
 # the format is the same as the openai API, since VLLM also provides and openai-style API.
 
@@ -8,6 +8,7 @@ defaults:
   logging_level: info # debug, info, warning, error, critical
   MODEL:
     engine: TODO # TODO path/to/vllm-supported/hf/model, vllm-supported huggingface model string, or openai model string
+    tensor_parallel_size: 1 # TODO number of gpus to use
     server_type: vllm # "vllm" or "openai"
     host: http://localhost # model server if using vllm
     port: 9741
@@ -22,4 +23,3 @@ defaults:
     PREMISE:
       max_tokens: 128
       stop: ["\n"]
-

--- a/scripts/story/config.yaml
+++ b/scripts/story/config.yaml
@@ -1,5 +1,5 @@
 # MODEL ARGS:
-# for model server / sampling args, you can put them under MODEL to be shared, 
+# for model server / sampling args, you can put them under MODEL to be shared,
 # or under the specific pipeline steps (STORY/PASSAGE/etc) for specific options. unspecified sampling args will inherit from the ancestor.
 # the format is the same as the openai API, since VLLM also provides and openai-style API.
 
@@ -12,6 +12,7 @@ defaults:
   logging_level: info # debug, info, warning, error, critical
   MODEL:
     engine: TODO # TODO path/to/vllm-supported/hf/model, vllm-supported huggingface model string, or openai model string
+    tensor_parallel_size: 1 # TODO number of gpus to use
     server_type: vllm # "vllm" or "openai"
     host: http://localhost # model server if using vllm
     port: 9741
@@ -44,7 +45,7 @@ defaults:
       SUMMARY: # summarizing parts of context when prompting for next passage
         max_tokens: 128
         stop: ["\n"]
-      SCORE: 
+      SCORE:
         # engine: # path/to/vllm-supported/hf/model, vllm-supported huggingface model string, or openai model string
         # server_type: vllm # "vllm" or "openai"
         # host: http://localhost # model server if using vllm

--- a/storygen/common/server.py
+++ b/storygen/common/server.py
@@ -9,21 +9,23 @@ DEFAULT_PORT = 8000
 
 
 class ServerConfig:
-    def __init__(self, engine, host, port, server_type):
+    def __init__(self, engine, host, port, server_type, tensor_parallel_size):
         self.engine = engine
         self.host = host
         self.port = port
         self.server_type = server_type
-    
+        self.tensor_parallel_size = tensor_parallel_size
+
     @staticmethod
     def from_config(config):
         return ServerConfig(
             engine=config['engine'],
             host=config['host'],
             port=config.get('port', DEFAULT_PORT),
-            server_type=config['server_type']
+            server_type=config['server_type'],
+            tensor_parallel_size=config['tensor_parallel_size']
         )
-    
+
     @staticmethod
     def from_json(json_str):
         return ServerConfig(**json.loads(json_str))
@@ -33,17 +35,19 @@ class ServerConfig:
             'engine': self.engine,
             'host': self.host,
             'port': self.port,
-            'server_type': self.server_type
+            'server_type': self.server_type,
+            'tensor_parallel_size': self.tensor_parallel_size
         })
 
     def __getitem__(self, key):
         return getattr(self, key)
-    
+
     def __hash__(self):
-        return hash((self.engine, self.host, self.port, self.server_type))
+        return hash((self.engine, self.host, self.port,
+                     self.server_type, self.tensor_parallel_size))
 
     def __eq__(self, other):
-        return (self.engine, self.host, self.port, self.server_type) == (other.engine, other.host, other.port, other.server_type)
+        return (self.engine, self.host, self.port, self.server_type, self.tensor_parallel_size) == (other.engine, other.host, other.port, other.server_type, self.tensor_parallel_size)
 
 
 def start_server(config):
@@ -61,11 +65,12 @@ def start_server(config):
         logging.info(f"Server for {config['engine']} already started.")
         return
     if config['host'] == LOCALHOST and config['server_type'] == 'vllm':
-        logging.info(f"Starting vllm server for {config['engine']} on port {config['port']}... (it's ready when it says \"Uvicorn running\")")
+        logging.info(f"Starting vllm server for {config['engine']} on port {config['port']} with {config['tensor_parallel_size']} GPUs... (it's ready when it says \"Uvicorn running\")")
         # run vllm openai-interface server
         # try:
         os.system(f"python -u -m vllm.entrypoints.openai.api_server \
                         --model {config['engine']} \
+                        --tensor-parallel-size {config['tensor_parallel_size']} \
                         --port {config['port']} &")
         #     logging.info(f"Started vllm server for {config['engine']} on port {config['port']}!")
         # except:


### PR DESCRIPTION
The current implementation does not support multi-GPU inference – adding the `tensor_parallel_size` argument when launching the vLLM process.